### PR TITLE
Added availability to write examples on @ApiModelProperty

### DIFF
--- a/src/author/author.model.ts
+++ b/src/author/author.model.ts
@@ -11,12 +11,14 @@ import {
 export class AuthorModel {
   @ApiModelProperty({
     description: "Id of author",
+    example: 1,
     required: true
   })
-  public id: string;
+  public id: string | number;
 
   @ApiModelProperty({
     description: "Name of author",
+    example: "John Doe",
     required: true,
     itemType: SwaggerDefinitionConstant.Model.Property.Type.STRING
   })

--- a/src/lib/swagger-express-ts/api-model-property.decorator.ts
+++ b/src/lib/swagger-express-ts/api-model-property.decorator.ts
@@ -42,6 +42,12 @@ export interface IApiModelPropertyArgs {
    * Optional.
    */
   itemType?: string;
+
+  /**
+   * Define example.
+   * Optional.
+   */
+  example?: string | number;
 }
 
 export function ApiModelProperty(

--- a/src/lib/swagger-express-ts/i-swagger.ts
+++ b/src/lib/swagger-express-ts/i-swagger.ts
@@ -102,6 +102,7 @@ export interface ISwaggerDefinitionProperty {
   format?: string; // Example : SwaggerDefinition.Definition.Property.Format.INT_64
   required?: boolean;
   description?: string;
+  example?: string | number;
   enum?: string[];
   items?: ISwaggerDefinitionPropertyItems;
   $ref?: string;

--- a/src/lib/swagger-express-ts/swagger.builder.ts
+++ b/src/lib/swagger-express-ts/swagger.builder.ts
@@ -43,6 +43,11 @@ export interface ISwaggerBuildDefinitionModelProperty {
    * Optional.
    */
   description?: string;
+  /**
+   * Define example.
+   * Optional.
+   */
+  example?: string | number;
 
   /**
    * Define type of item. Example: SwaggerDefinitionConstant.Definition.Property.Type.STRING

--- a/src/lib/swagger-express-ts/swagger.service.ts
+++ b/src/lib/swagger-express-ts/swagger.service.ts
@@ -171,6 +171,9 @@ export class SwaggerService {
                 type: property.itemType
               };
             }
+            if (property.example) {
+              newProperty.example = property.example;
+            }
             if (property.model) {
               if (
                 _.isEqual(
@@ -188,6 +191,7 @@ export class SwaggerService {
             if (property.required) {
               newDefinition.required.push(propertyIndex);
             }
+
             newDefinition.properties[propertyIndex] = newProperty;
 
             definitions[modelIndex] = newDefinition;
@@ -416,6 +420,7 @@ export class SwaggerService {
       swaggerBuildDefinitionModelProperty.description = args.description;
       swaggerBuildDefinitionModelProperty.enum = args.enum;
       swaggerBuildDefinitionModelProperty.itemType = args.itemType;
+      swaggerBuildDefinitionModelProperty.example = args.example;
       if (args.model) {
         swaggerBuildDefinitionModelProperty.model = args.model;
         if (!_.isEqual("Array", propertyType)) {

--- a/src/version/version.model.ts
+++ b/src/version/version.model.ts
@@ -8,18 +8,21 @@ import { AuthorModel } from "../author/author.model";
 export class VersionModel {
   @ApiModelProperty({
     description: "Id of version",
+    example: 1,
     required: true
   })
-  public id: string;
+  public id: string | number;
 
   @ApiModelProperty({
     description: "",
+    example: "New version",
     required: true
   })
   public name: string;
 
   @ApiModelProperty({
     description: "Description of version",
+    example: "My awesome description",
     required: true
   })
   public description: string;

--- a/src/version/versions.service.ts
+++ b/src/version/versions.service.ts
@@ -13,7 +13,7 @@ export class VersionsService {
       description: "Description Version 1",
       author: {
         id: "1",
-        name: ["John DOE"]
+        name: ["John Doe"]
       }
     },
     {
@@ -22,7 +22,7 @@ export class VersionsService {
       description: "Description Version 2",
       author: {
         id: "1",
-        name: ["John DOE"]
+        name: ["John Doe"]
       }
     }
   ];


### PR DESCRIPTION
Added possibility for writing examples inside `ApiModelProperty` decorator.

```
@ApiModelProperty({
    description: "Description of version",
    example: "My awesome description",
    required: true
  })
  public description: string;
```