### PR TITLE
Add custom headers for responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3431,12 +3431,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3451,17 +3453,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3578,7 +3583,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3590,6 +3596,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3604,6 +3611,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3611,12 +3619,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3635,6 +3645,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3715,7 +3726,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3727,6 +3739,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3848,6 +3861,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11686,7 +11700,7 @@
     },
     "sinon": {
       "version": "4.5.0",
-      "resolved": "http://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
       "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {

--- a/src/lib/swagger-express-ts/builders/response.builder.spec.ts
+++ b/src/lib/swagger-express-ts/builders/response.builder.spec.ts
@@ -55,6 +55,34 @@ describe("ResponseBuilder", () => {
     });
   });
 
+  describe("response headers", () => {
+    it("should return response with explicit headers", () => {
+      const expected = {
+        200: {
+          description: "this is a test response",
+          headers: {
+            "x-test-header": {
+              type: "string",
+              description: "this is a test header"
+            }
+          }
+        }
+      };
+
+      const response = {
+        description: "this is a test response",
+        headers: {
+          "x-test-header": {
+            type: "string",
+            description: "this is a test header"
+          }
+        }
+      };
+      responseBuilder.withResponses({ 200: response });
+      expect(responseBuilder.build()).to.be.deep.equal(expected);
+    });
+  });
+
   /**
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject}
    */

--- a/src/lib/swagger-express-ts/builders/response.builder.ts
+++ b/src/lib/swagger-express-ts/builders/response.builder.ts
@@ -44,6 +44,11 @@ export class ResponseBuilder {
           +responseIndex
         );
 
+        ResponseBuilder.handleResponseHeaders(
+          response,
+          newSwaggerOperationResponse
+        );
+
         if (response.model) {
           newSwaggerOperationResponse.schema = this.createResponseByModel(
             response
@@ -58,6 +63,15 @@ export class ResponseBuilder {
       }
     }
     return swaggerOperationResponses;
+  }
+
+  private static handleResponseHeaders(
+    response: IApiOperationArgsBaseResponse,
+    newSwaggerOperationResponse: ISwaggerOperationResponse
+  ) {
+    if (response.hasOwnProperty("headers")) {
+      newSwaggerOperationResponse.headers = response.headers;
+    }
   }
 
   private static handleResponseDescription(

--- a/src/lib/swagger-express-ts/i-api-operation-args.base.ts
+++ b/src/lib/swagger-express-ts/i-api-operation-args.base.ts
@@ -12,8 +12,14 @@ export interface IApiOperationArgsBaseParameter {
 
 export interface IApiOperationArgsBaseResponse {
   description?: string;
+  headers?: { [key: string]: IApiOperationArgsBaseResponseHeader };
   type?: DataType;
   model?: string | DataType;
+}
+
+export interface IApiOperationArgsBaseResponseHeader {
+  type: string;
+  description: string;
 }
 
 export interface IApiOperationArgsBaseParameters {

--- a/src/lib/swagger-express-ts/i-swagger.ts
+++ b/src/lib/swagger-express-ts/i-swagger.ts
@@ -50,6 +50,11 @@ export interface ISwaggerOperationParameter {
   schema?: ISwaggerOperationSchema;
 }
 
+export interface ISwaggerOperationResponseHeader {
+  type?: string;
+  description?: string;
+}
+
 export interface ISwaggerOperationSchema {
   type?: string;
   items?: {
@@ -63,6 +68,7 @@ export interface ISwaggerOperationSchema {
 
 export interface ISwaggerOperationResponse {
   description: string;
+  headers?: ISwaggerOperationResponseHeader;
   schema?: ISwaggerOperationSchema;
 }
 

--- a/src/version/versions.controller.ts
+++ b/src/version/versions.controller.ts
@@ -11,7 +11,7 @@ import {
   ApiOperationGet,
   ApiOperationPost,
   ApiPath,
-  DataType
+  DataType,
 } from "../lib/swagger-express-ts";
 import { VersionsService } from "./versions.service";
 import { VersionModel } from "./version.model";
@@ -36,6 +36,12 @@ export class VersionsController implements interfaces.Controller {
     summary: "Get versions list",
     responses: {
       200: {
+        headers: {
+          "x-custom-header": {
+            type: "string",
+            description: "This is a custom header"
+          }
+        },
         type: DataType.array,
         model: "Version"
       }


### PR DESCRIPTION
Added the option to include custom headers on @IApiOperationArgsBaseResponse #3 
``` js 
@ApiOperationGet({
    description: "Get versions objects list",  
    summary: "Get versions list",
    responses: {
      200: {
        headers: {
          "x-custom-header": {
            type: "string",
            description: "This is a custom header"
          }
        },
        type: DataType.array,
        model: "Version"
      }
    },
    security: {
      apiKeyHeader: []
    }
  })`
